### PR TITLE
update the build to support inux/amd64,linux/arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE_NAME }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
 


### PR DESCRIPTION
## Summary by Sourcery

Enable multi-architecture Docker image builds in CI by adding support for linux/amd64 and linux/arm64 platforms.

New Features:
- Support building Docker images for linux/amd64 and linux/arm64 architectures

CI:
- Add 'platforms' specification to the CI workflow to produce multi-arch images