### PR TITLE
only publish docker from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,14 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Log in to Docker Hub
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image with cache
+        if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add `if: github.ref == 'refs/heads/master'` conditions to the Docker login and build-push steps to prevent publishing from non-master branches.