### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD & Security
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
Potential fix for [https://github.com/ValeroK/trello-mcp-server/security/code-scanning/1](https://github.com/ValeroK/trello-mcp-server/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not perform any write operations on the repository. This change will ensure that the `GITHUB_TOKEN` is restricted to read-only access to repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add a permissions block to the CI/CD workflow to restrict GITHUB_TOKEN to read-only access to repository contents and address the code scanning alert

Bug Fixes:
- Define minimal permissions in the workflow to fix the code scanning alert

CI:
- Add a permissions section with contents: read to the CI/CD workflow