### PR TITLE
update docker build to use github and introduce a health endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
-# Git
+# Version Control
 .git
 .gitignore
+.gitattributes
 
 # Python
 __pycache__/
@@ -8,7 +9,6 @@ __pycache__/
 *$py.class
 *.so
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -24,27 +24,62 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.pytest_cache/
+.coverage
+htmlcov/
 
 # Virtual Environment
+.venv/
 venv/
 ENV/
+env/
 
 # IDE
 .idea/
 .vscode/
 *.swp
 *.swo
+*.sublime-*
+.project
+.pydevproject
+.settings/
 
 # Docker
 Dockerfile
 .dockerignore
+docker-compose*.yml
+.docker/
 
-# Environment variables
+# Environment and Secrets
 .env
 .env.*
+*.pem
+*.key
+*.crt
+secrets/
+credentials/
 
-# Logs
+# Logs and Databases
 *.log
+*.sqlite
+*.db
+logs/
+data/
 
-# Local development
-.DS_Store 
+# OS and Editor
+.DS_Store
+Thumbs.db
+*.bak
+*.tmp
+*.temp
+
+# Build and Cache
+.ruff_cache/
+.mypy_cache/
+__pycache__/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+.hypothesis/ 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,63 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run Grype vulnerability scanner
+        uses: anchore/grype-action@v1
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          fail-on: high
+          output: table 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,65 @@
+# Build stage
+FROM python:3.12-slim as builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv and create virtual environment
+RUN pip install --no-cache-dir uv && \
+    python -m venv /app/.venv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies
+RUN . /app/.venv/bin/activate && \
+    uv pip install --system -e . && \
+    pip install --no-cache-dir fastmcp==2.5.1 fastapi uvicorn
+
+# Final stage
 FROM python:3.12-slim
 
 WORKDIR /app
 
-# Install only necessary system dependencies for build, then remove them
-COPY pyproject.toml uv.lock ./
+# Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential && \
-    pip install --no-cache-dir uv && \
-    uv pip install --system -e . && \
-    pip install --no-cache-dir fastmcp==2.5.1 && \
-    apt-get purge -y --auto-remove build-essential && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get install -y --no-install-recommends \
+    tini \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment from builder
+COPY --from=builder /app/.venv /app/.venv
 
 # Copy application code
 COPY . .
 
-# Create non-root user and set ownership
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+# Create non-root user and group
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid appgroup --shell /bin/bash --create-home appuser && \
+    chown -R appuser:appgroup /app
 
 # Set default environment variables
-ENV PYTHONUNBUFFERED=1
-ENV USE_CLAUDE_APP=false
-ENV MCP_SERVER_NAME="Trello MCP Server"
-ENV MCP_SERVER_HOST=0.0.0.0
-ENV MCP_SERVER_PORT=8000
+ENV PYTHONUNBUFFERED=1 \
+    USE_CLAUDE_APP=false \
+    MCP_SERVER_NAME="Trello MCP Server" \
+    MCP_SERVER_HOST=0.0.0.0 \
+    MCP_SERVER_PORT=8952
 
 # Expose port
 EXPOSE ${MCP_SERVER_PORT}
 
+# Copy and set up entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Switch to non-root user
 USER appuser
 
-# Run the application
-CMD ["python", "main.py"] 
+# Use tini as init system
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"] 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,27 +1,37 @@
 version: '3.8'
 
 services:
-  trello-mcp-server:
-    container_name: trello-mcp-server
+  trello-mcp:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "${MCP_SERVER_PORT:-8952}:${MCP_SERVER_PORT:-8952}"
-    network_mode: host
-    volumes:
-      - .:/app
-    env_file:
-      - .env
+    image: trello-mcp:latest
+    container_name: trello-mcp
     restart: unless-stopped
+    environment:
+      - USE_CLAUDE_APP=${USE_CLAUDE_APP:-false}
+      - MCP_SERVER_NAME=${MCP_SERVER_NAME:-"Trello MCP Server"}
+      - MCP_SERVER_HOST=${MCP_SERVER_HOST:-0.0.0.0}
+      - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8952}
+      - TRELLO_API_KEY=${TRELLO_API_KEY}
+      - TRELLO_API_SECRET=${TRELLO_API_SECRET}
+      - TRELLO_TOKEN=${TRELLO_TOKEN}
+    ports:
+      - "${MCP_SERVER_PORT:-8952}:8952"
+      - "8953:8953"
+    volumes:
+      - ./logs:/app/logs
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8952/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     deploy:
       resources:
         limits:
           cpus: '1'
           memory: 512M
-        reservations:
-          cpus: '0.25'
-          memory: 128M
     logging:
       driver: "json-file"
       options:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Ensure required directories exist and have correct permissions
+mkdir -p /app/logs
+chown -R appuser:appgroup /app
+
+# Activate virtual environment if needed
+if [ -d "/app/.venv" ]; then
+    source /app/.venv/bin/activate
+fi
+
+# Function to handle graceful shutdown
+cleanup() {
+    echo "Received shutdown signal, cleaning up..."
+    # Add any cleanup tasks here
+    exit 0
+}
+
+# Trap SIGTERM and SIGINT
+trap cleanup SIGTERM SIGINT
+
+# Start the application
+echo "Starting Trello MCP Server..."
+exec python main.py 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import server.tools.board as board  # noqa: F401
 import server.tools.card as card  # noqa: F401
 import server.tools.list as list  # noqa: F401
 import server.tools.checklist as checklist  # noqa: F401
+import server.health_app  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ logger.addHandler(console_handler)
 load_dotenv()
 
 host = os.getenv("MCP_SERVER_HOST", "0.0.0.0")
-port = int(os.getenv("MCP_SERVER_PORT", "8000"))
+port = int(os.getenv("MCP_SERVER_PORT", "8952"))
 mcp.settings.host = host
 mcp.settings.port = port
 

--- a/server/DOCKER_METHODOLOGY.md
+++ b/server/DOCKER_METHODOLOGY.md
@@ -1,0 +1,116 @@
+# Docker & CI/CD Methodology and Best Practices
+
+## Overview
+This document describes the Docker implementation, CI/CD workflow, and best practices used in this project. It is designed to be a template for transforming any codebase to use these robust, secure, and maintainable containerization and automation strategies.
+
+---
+
+## 1. Multi-Stage Docker Builds
+
+- **Builder Stages:**
+  - Use separate stages for each language/runtime (e.g., Go, Python).
+  - Build artifacts (binaries, virtual environments) in isolated builder stages.
+  - Only copy the final build outputs to the runtime image.
+- **Final Stage:**
+  - Use a minimal, secure base image (e.g., `python:3.11-slim`).
+  - Install only runtime dependencies (e.g., `ffmpeg`, `tini`, `curl`).
+  - Copy built artifacts and static assets.
+  - Set up persistent data volumes as needed.
+  - Expose only required ports.
+
+### Example: Non-Root User
+- Create a dedicated user and group (e.g., `appuser:appgroup`).
+- Set ownership of all application and data directories to this user.
+- Use the `USER` directive to run the container as non-root for security.
+
+```
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid 1001 --shell /bin/bash --create-home appuser
+USER appuser
+```
+
+---
+
+## 2. Entrypoint Script
+- Use an entrypoint script to:
+  - Ensure required directories exist and have correct permissions.
+  - Start background services if needed.
+  - Activate virtual environments or other runtime setups.
+  - Run the main application in the foreground for proper container lifecycle management.
+- Trap signals (SIGTERM/SIGINT) for graceful shutdown.
+
+---
+
+## 3. .dockerignore
+- Exclude unnecessary files from the build context:
+  - VCS files (e.g., `.git/`)
+  - Local data, build artifacts, OS files
+  - Example: `whatsapp-bridge/store/`, `*.db`, `__pycache__/`, `.DS_Store`
+- This keeps images small, secure, and fast to build.
+
+---
+
+## 4. GitHub Actions for CI/CD
+- **Build & Push Workflow:**
+  - Trigger on push to `main`, PRs, and manual dispatch.
+  - Use [GitVersion](https://gitversion.net/) for semantic versioning.
+  - Use QEMU and Buildx for multi-platform builds (`linux/amd64`, `linux/arm64`).
+  - Push images to a container registry (e.g., GHCR).
+  - Use build cache and provenance for efficiency and traceability.
+  - Tag images with `latest`, semver, and optional suffixes.
+- **Static Content Deployment:**
+  - Use a separate workflow to deploy static assets (e.g., to GitHub Pages).
+
+---
+
+## 5. Best Practices
+- **Security:**
+  - Always run containers as a non-root user.
+  - Minimize the final image size and attack surface.
+  - Use `tini` or a similar init system for signal handling.
+- **Maintainability:**
+  - Use multi-stage builds to separate build and runtime concerns.
+  - Keep Dockerfiles and entrypoint scripts well-documented.
+  - Use `.dockerignore` to avoid leaking sensitive or unnecessary files.
+- **Automation:**
+  - Automate builds, tests, and deployments with CI/CD workflows.
+  - Use semantic versioning for traceability.
+  - Build for all required platforms.
+
+---
+
+## 6. How to Apply This Methodology to Any Codebase
+
+1. **Create a multi-stage Dockerfile** for each language/runtime.
+2. **Add an entrypoint script** to orchestrate startup and ensure permissions.
+3. **Add a `.dockerignore` file** to exclude unnecessary files.
+4. **Add a GitHub Actions workflow** for Docker build/push, using semantic versioning and multi-platform builds.
+5. **(Optional) Add a workflow for static content deployment** if needed.
+6. **Document all steps and scripts** so future maintainers can understand and extend the setup.
+
+---
+
+## 7. Example Directory Structure
+```
+/your-project
+├── Dockerfile
+├── entrypoint.sh
+├── .dockerignore
+├── .github/
+│   └── workflows/
+│       ├── docker-build.yml
+│       └── static.yml
+└── ...
+```
+
+---
+
+## 8. References
+- [Docker Best Practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [GitVersion](https://gitversion.net/)
+- [Tini](https://github.com/krallin/tini)
+
+---
+
+**This methodology ensures secure, reproducible, and maintainable containerized applications with automated CI/CD.** 

--- a/server/health_app.py
+++ b/server/health_app.py
@@ -1,0 +1,33 @@
+from server.mcp_instance import mcp
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
+import os
+import httpx
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    # Check for required environment variables
+    if not os.getenv("TRELLO_API_KEY") or not os.getenv("TRELLO_TOKEN"):
+        return JSONResponse(
+            {"status": "unhealthy", "reason": "Missing Trello credentials"},
+            status_code=HTTP_503_SERVICE_UNAVAILABLE
+        )
+    # Check Trello API connectivity
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://api.trello.com/1/members/me",
+                params={
+                    "key": os.getenv("TRELLO_API_KEY"),
+                    "token": os.getenv("TRELLO_TOKEN")
+                },
+                timeout=5.0
+            )
+            response.raise_for_status()
+    except Exception as e:
+        return JSONResponse(
+            {"status": "unhealthy", "reason": f"Trello API error: {str(e)}"},
+            status_code=HTTP_503_SERVICE_UNAVAILABLE
+        )
+    return JSONResponse({"status": "healthy", "trello_connection": "ok", "version": "1.0.0"}) 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the containerization setup with a multi-stage Docker build, custom entrypoint, updated compose configuration, and add a /health endpoint, backed by a new GitHub Actions pipeline for building, pushing, and scanning images

New Features:
- Expose a health endpoint at /health to report service and Trello API connectivity status

Enhancements:
- Refactor Dockerfile into a multi-stage build with separate builder and runtime stages and a virtual environment
- Integrate tini as init and add an entrypoint script for permission setup and graceful shutdown
- Update docker-compose configuration with restart policy, healthcheck, environment variables, logging volume, and expose the default port
- Change the default MCP server port from 8000 to 8952

CI:
- Add a GitHub Actions workflow to build and push multi-platform Docker images and run Grype vulnerability scanning

Documentation:
- Add Docker & CI/CD methodology and best practices documentation