### PR TITLE
update docker build and tagging also update readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-check:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: valerok86/trello-mcp-server:latest
+      IMAGE_NAME: ghcr.io/valerok/trello-mcp-server:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -120,8 +120,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            # Push 'latest' tag only for main branch pushes
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Push 'latest' tag only for master branch pushes
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
             # Push semver tags (e.g., v1.2.3)
             type=raw,value=${{ needs.version.outputs.version }}
             # Push major.minor.patch tag (e.g., 1.2.3)
@@ -161,7 +161,7 @@ jobs:
 
       - name: Scan image with Anchore Grype
         if: github.event_name != 'pull_request'
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v6
         with:
           image: ghcr.io/${{ github.repository }}:latest
           fail-build: false

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To get started quickly, follow these steps:
      ```env
      TRELLO_API_KEY=your_trello_api_key_here
      TRELLO_TOKEN=your_trello_token_here
+     MCP_SERVER_HOST=127.0.0.1
      # ...other settings...
      ```
 
@@ -27,7 +28,7 @@ To get started quickly, follow these steps:
      --env-file .env \
      --network host \
      -p 8952:8952 \
-     valerok86/trello-mcp-server:latest
+     ghcr.io/valerok/trello-mcp-server:latest
    ```
    This will start the server in detached mode, using your `.env` file for configuration.
    - With `--network host`, the container will listen on the same network interfaces as your host machine.
@@ -153,13 +154,13 @@ docker-compose down
 - A pre-built image is available at Docker Hub and is updated automatically by CI:
 
 ```bash
-docker pull valerok86/trello-mcp-server:latest
+docker pull ghcr.io/valerok/trello-mcp-server:latest
 ```
 
 Then run it with your `.env` file mounted:
 
 ```bash
-docker run --env-file .env -p 8952:8952 valerok86/trello-mcp-server:latest
+docker run --env-file .env -p 8952:8952 ghcr.io/valerok/trello-mcp-server:latest
 ```
 
 ##### How to Prepare Your `.env` File
@@ -178,7 +179,7 @@ docker run --env-file .env -p 8952:8952 valerok86/trello-mcp-server:latest
      TRELLO_API_KEY=your_trello_api_key_here
      TRELLO_TOKEN=your_trello_token_here
      USE_CLAUDE_APP=false
-     MCP_SERVER_HOST=0.0.0.0
+     MCP_SERVER_HOST=127.0.0.1
      MCP_SERVER_PORT=8952
      ```
    - You can get your Trello API key and token by following the instructions in the "Installation" section above.
@@ -204,8 +205,8 @@ docker run --env-file .env -p 8952:8952 valerok86/trello-mcp-server:latest
    # (edit .env with your credentials)
 
    # Pull and run the Docker image
-   docker pull valerok86/trello-mcp-server:latest
-   docker run --env-file .env -p 8952:8952 valerok86/trello-mcp-server:latest
+   docker pull ghcr.io/valerok/trello-mcp-server:latest
+   docker run --env-file .env -p 8952:8952 ghcr.io/valerok/trello-mcp-server:latest
    ```
 
 This allows you to get started quickly without building the image locally.
@@ -219,7 +220,7 @@ The server can be configured using environment variables in the `.env` file:
 | TRELLO_API_KEY | Your Trello API key | Required |
 | TRELLO_TOKEN | Your Trello API token | Required |
 | MCP_SERVER_NAME | The name of the MCP server | Trello MCP Server |
-| MCP_SERVER_HOST | Host address for SSE mode | 0.0.0.0 |
+| MCP_SERVER_HOST | Host address for SSE mode | 127.0.0.1 |
 | MCP_SERVER_PORT | Port for SSE mode | 8952 |
 | USE_CLAUDE_APP | Whether to use Claude app mode | true |
 
@@ -250,7 +251,7 @@ To connect your MCP server to Cursor:
 
 1. Run the server in SSE mode (`USE_CLAUDE_APP=false`)
 2. In Cursor, go to Settings (gear icon) > AI > Model Context Protocol
-3. Add a new server with URL `http://localhost:8952` (or your configured host/port), alternative to use dokcer 127.0.0.1 (not exposed to the outside work) and in the scp configuraiton use "url": `http://host.docker.internal:8952/sse`
+3. Add a new server with URL `http://localhost:8952/sse` 
 4. Select the server when using Cursor's AI features
 
 You can also add this configuration to your Cursor settings JSON file (typically at `~/.cursor/mcp.json`):
@@ -259,37 +260,6 @@ You can also add this configuration to your Cursor settings JSON file (typically
 {
   "mcpServers": {
     "trello-mcp": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "--name",
-        "trello-mcp",
-        "-e",
-        "TRELLO_API_KEY",
-        "-e",
-        "TRELLO_TOKEN",
-        "-e",
-        "USE_CLAUDE_APP",
-        "-e",
-        "MCP_SERVER_HOST",
-        "-e",
-        "MCP_SERVER_PORT",
-        "-e",
-        "MCP_SERVER_NAME",
-        "-p",
-        "8952:8952",
-        "valerok86/trello-mcp-server:latest"
-      ],
-      "env": {
-        "TRELLO_API_KEY": "your_api_key",
-        "TRELLO_TOKEN": "your_token",
-        "USE_CLAUDE_APP": "false",
-        "MCP_SERVER_HOST": "0.0.0.0",
-        "MCP_SERVER_PORT": "8952",
-        "MCP_SERVER_NAME": "Trello MCP Server"
-      },
       "url": "http://localhost:8952/sse"
   }
 }
@@ -446,25 +416,6 @@ This makes it easy to authorize the app for any Trello user without manual URL c
 ```
 https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-post 
 ```
-
-### Overriding .env Configurations with Docker
-
-You can override any configuration from your `.env` file by passing environment variables directly to the container using the `-e` flag with `docker run`. In fact, you can provide all configuration parameters this way, making the `.env` file optional. For example:
-
-```sh
-docker run \
-  -e TRELLO_API_KEY=your_api_key \
-  -e TRELLO_TOKEN=your_token \
-  -e USE_CLAUDE_APP=false \
-  -e MCP_SERVER_HOST=0.0.0.0 \
-  -e MCP_SERVER_PORT=8952 \
-  -e MCP_SERVER_NAME="Trello MCP Server" \
-  -p 8952:8952 \
-  valerok86/trello-mcp-server:latest
-```
-
-- Make sure your `.env` file is set up with your Trello credentials before running the server.
-- For more advanced usage, see the rest of this README.
 
 ## Trello Open API documnetation
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - TRELLO_API_KEY=${TRELLO_API_KEY}
       - TRELLO_API_SECRET=${TRELLO_API_SECRET}
       - TRELLO_TOKEN=${TRELLO_TOKEN}
+    network_mode: host
     ports:
       - "${MCP_SERVER_PORT:-8952}:8952"
       - "8953:8953"


### PR DESCRIPTION
## Summary by Sourcery

Update Docker workflows to use GitHub Container Registry, adjust CI tags and scanning action, refine container networking and default host settings, and refresh README examples accordingly.

CI:
- Switch CI image name to ghcr.io/valerok repository
- Update docker-build workflow to tag on master branch
- Bump Anchore Grype scan-action to v6

Deployment:
- Add host network mode to docker-compose service

Documentation:
- Change default MCP_SERVER_HOST to 127.0.0.1 across README
- Replace Docker Hub image references with GHCR paths
- Remove outdated Cursor JSON example and override section